### PR TITLE
remove webkit prefix from border-radius mixins

### DIFF
--- a/sass/custom/_general.scss
+++ b/sass/custom/_general.scss
@@ -85,7 +85,7 @@ blockquote {
 .pager li>span,
 .card,
 .modal-content {
-  @include border-radius($border-radius);
+  border-radius: $border-radius;
 }
 
 .card .card__image img,

--- a/sass/custom/_live_css.scss
+++ b/sass/custom/_live_css.scss
@@ -34,7 +34,7 @@
 .live-css-v-f-secondary { font-family: $f-secondary; }
 .live-css-v-f-body { font-family: $f-body; }
 
-.live-css-v-o-border-radius i { background: $gray-light; @include border-radius($border-radius); }
+.live-css-v-o-border-radius i { background: $gray-light; border-radius: $border-radius; }
 
 .ico-live-chat-bubble {
   width: 30px;

--- a/sass/custom/_mixins.scss
+++ b/sass/custom/_mixins.scss
@@ -14,36 +14,23 @@
   box-sizing: $box-model;
 }
 
-@mixin border-radius($radius) {
-  -webkit-border-radius: $radius;
-  border-radius: $radius;
-}
-
 @mixin border-top-radius($radius) {
-  -webkit-border-top-right-radius: $radius;
   border-top-right-radius: $radius;
-  -webkit-border-top-left-radius: $radius;
   border-top-left-radius: $radius;
 }
 
 @mixin border-right-radius($radius) {
-  -webkit-border-bottom-right-radius: $radius;
   border-bottom-right-radius: $radius;
-  -webkit-border-top-right-radius: $radius;
   border-top-right-radius: $radius;
 }
 
 @mixin border-bottom-radius($radius) {
-  -webkit-border-bottom-right-radius: $radius;
   border-bottom-right-radius: $radius;
-  -webkit-border-bottom-left-radius: $radius;
   border-bottom-left-radius: $radius;
 }
 
 @mixin border-left-radius($radius) {
-  -webkit-border-bottom-left-radius: $radius;
   border-bottom-left-radius: $radius;
-  -webkit-border-top-left-radius: $radius;
   border-top-left-radius: $radius;
 }
 


### PR DESCRIPTION
Less than 1% of browsers still require this fix on border-radius. Only needed for Firefox 3.6-, Safari 4-, iOS 3.2-, or Android 2.3- or older. Absolute worse case is that we get square corners on these devices. 

A discussio on stack overflow here: http://stackoverflow.com/questions/27011871/should-i-still-use-vendor-prefixes-for-border-radius