### PR TITLE
Apply fixes for phpcs, remove unused code.

### DIFF
--- a/css/README.txt
+++ b/css/README.txt
@@ -1,3 +1,4 @@
 style.css is compiled from the Sass files.
 Don't directly modify the style.css file.
-Edit the .scss files in the Sass directory and compile style.css into this folder.
+Edit the .scss files in the Sass directory and compile style.css into this
+folder.

--- a/orange_starter.info.yml
+++ b/orange_starter.info.yml
@@ -2,7 +2,6 @@ name: Orange Starter
 type: theme
 description: 'Custom theme for our amazing clients.'
 package: Core
-version: '1.0.0'
 core: '8.x'
 base theme: orange_framework
 

--- a/orange_starter.theme
+++ b/orange_starter.theme
@@ -5,10 +5,9 @@
  * Functions to support theming.
  */
 
-use Drupal\Core\Template\Attribute;
 use Drupal\image\Entity\ImageStyle;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\Core\Url;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
@@ -23,7 +22,6 @@ function orange_starter_theme_suggestions_page_alter(array &$suggestions, array 
 
   // Add taxonomy vocabulary suggestions.
   if ($term = \Drupal::request()->attributes->get('taxonomy_term')) {
-    $vocabulary_id = $term->getVocabularyId();
     array_splice($suggestions, 1, 0, 'page__taxonomy__' . $term->getVocabularyId());
   }
 
@@ -38,11 +36,9 @@ function orange_starter_theme_suggestions_page_alter(array &$suggestions, array 
     $page_current_alias = str_replace('-', '_', $page_current_alias);
     $pos_page_current_alias = strpos($page_current_alias, $search_for);
 
-    if ($pos_page_current_alias !== false) {
+    if ($pos_page_current_alias !== FALSE) {
       $page_current_alias_formatted = substr_replace($page_current_alias, '', $pos_page_current_alias, strlen($search_for));
       $page_current_alias_formatted = str_replace('/', '__', $page_current_alias_formatted);
-    }
-    if ($page_current_alias_formatted) {
       array_splice($suggestions, 1, 0, 'page__' . $page_current_alias_formatted);
     }
   }
@@ -82,14 +78,14 @@ function orange_starter_preprocess_html(&$variables) {
 function orange_starter_preprocess_comment(&$variables) {
   $comment = $variables['elements']['#comment'];
 
-  $variables['created'] = t('@comment_date at @comment_time', array(
+  $variables['created'] = t('@comment_date at @comment_time', [
     '@comment_date' => \Drupal::service('date.formatter')->format($comment->getCreatedTime(), 'custom', 'F j, Y'),
-    '@comment_time' => \Drupal::service('date.formatter')->format($comment->getCreatedTime(), 'custom', 'g:i a')
-  ));
+    '@comment_time' => \Drupal::service('date.formatter')->format($comment->getCreatedTime(), 'custom', 'g:i a'),
+  ]);
 }
 
 /**
- * Implements hook_preprocess_node(&$variables).
+ * Implements hook_preprocess_node().
  */
 function orange_starter_preprocess_node(&$variables) {
   if (isset($variables['node'])) {
@@ -99,7 +95,7 @@ function orange_starter_preprocess_node(&$variables) {
     $variables['base_path'] = base_path();
 
     // Absolute path variable.
-    $node_absolute_url = \Drupal\Core\Url::fromRoute('entity.node.canonical', ['node' => $node->id()], ['absolute' => TRUE])->toString();
+    $node_absolute_url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], ['absolute' => TRUE])->toString();
     $variables['absolute_path'] = $node_absolute_url;
 
     // Encoded fields for social media sharing.
@@ -186,7 +182,7 @@ function orange_starter_preprocess_node(&$variables) {
 }
 
 /**
- * Implements hook_preprocess_page(&$variables).
+ * Implements hook_preprocess_page().
  */
 function orange_starter_preprocess_page(&$variables) {
   // Load the site name out of configuration.
@@ -205,29 +201,22 @@ function orange_starter_preprocess_page(&$variables) {
       $variables['homepage_carousel_view'] = views_embed_view($homepage_carousel_view_name, $homepage_carousel_view_display);
     }
   }
-
-  // Node.
-  if (isset($variables['node'])) {
-    $node = $variables['node'];
-  }
 }
 
 /**
- * Implements hook_preprocess_taxonomy_term(&$variables).
+ * Implements hook_preprocess_taxonomy_term().
  */
 function orange_starter_preprocess_taxonomy_term(&$variables) {
   if (isset($variables['term'])) {
-    $term = $variables['term'];
-
     // Set base path variable.
     $variables['base_path'] = base_path();
   }
 }
 
 /**
- * Implements hook_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id).
+ * Implements hook_form_alter().
  */
-function orange_starter_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id){
+function orange_starter_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Comment form.
   if ($form_id == 'comment_node_comment_form') {
     // Update submit button text.


### PR DESCRIPTION
This fixes the following issues found by phpcs.

```
$ phpcs --standard=Drupal . --ignore=.css

FILE: ...home/tbradbury/src/drupal/orange_starter/orange_starter.info.yml
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 1 | WARNING | Remove "version" from the info file, it will be added
   |         | by drupal.org packaging automatically
----------------------------------------------------------------------


FILE: /home/tbradbury/src/drupal/orange_starter/orange_starter.theme
----------------------------------------------------------------------
FOUND 5 ERRORS AND 8 WARNINGS AFFECTING 11 LINES
----------------------------------------------------------------------
   8 | WARNING | [x] Unused use statement
  10 | WARNING | [x] Unused use statement
  41 | ERROR   | [x] TRUE, FALSE and NULL must be uppercase; expected
     |         |     "FALSE" but found "false"
  85 | ERROR   | [x] Short array syntax must be used to define arrays
  87 | WARNING | [x] A comma should follow the last multiline array
     |         |     item. Found: )
  92 | WARNING | [ ] Format should be "* Implements hook_foo().", "*
     |         |     Implements hook_foo_BAR_ID_bar() for
     |         |     xyz_bar().",, "* Implements
     |         |     hook_foo_BAR_ID_bar() for xyz-bar.html.twig.",
     |         |     "* Implements hook_foo_BAR_ID_bar() for
     |         |     xyz-bar.tpl.php.", or "* Implements
     |         |     hook_foo_BAR_ID_bar() for block templates."
 102 | ERROR   | [x] Namespaced classes/interfaces/traits should be
     |         |     referenced with use statements
 189 | WARNING | [ ] Format should be "* Implements hook_foo().", "*
     |         |     Implements hook_foo_BAR_ID_bar() for
     |         |     xyz_bar().",, "* Implements
     |         |     hook_foo_BAR_ID_bar() for xyz-bar.html.twig.",
     |         |     "* Implements hook_foo_BAR_ID_bar() for
     |         |     xyz-bar.tpl.php.", or "* Implements
     |         |     hook_foo_BAR_ID_bar() for block templates."
 216 | WARNING | [ ] Format should be "* Implements hook_foo().", "*
     |         |     Implements hook_foo_BAR_ID_bar() for
     |         |     xyz_bar().",, "* Implements
     |         |     hook_foo_BAR_ID_bar() for xyz-bar.html.twig.",
     |         |     "* Implements hook_foo_BAR_ID_bar() for
     |         |     xyz-bar.tpl.php.", or "* Implements
     |         |     hook_foo_BAR_ID_bar() for block templates."
 228 | WARNING | [ ] Line exceeds 80 characters; contains 98
     |         |     characters
 228 | WARNING | [ ] Format should be "* Implements hook_foo().", "*
     |         |     Implements hook_foo_BAR_ID_bar() for
     |         |     xyz_bar().",, "* Implements
     |         |     hook_foo_BAR_ID_bar() for xyz-bar.html.twig.",
     |         |     "* Implements hook_foo_BAR_ID_bar() for
     |         |     xyz-bar.tpl.php.", or "* Implements
     |         |     hook_foo_BAR_ID_bar() for block templates."
 230 | ERROR   | [x] Namespaced classes/interfaces/traits should be
     |         |     referenced with use statements
 230 | ERROR   | [x] Expected 1 space before opening brace; found 0
----------------------------------------------------------------------
PHPCBF CAN FIX THE 8 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------

Time: 100ms; Memory: 8Mb
```

I also made a couple other changes that removed unused code or, in one case, fixed an issue where a variable may be undefined.

There's a few other things that looked funny:

```php
/**
 * Implements hook_preprocess_taxonomy_term().
 */
function orange_starter_preprocess_taxonomy_term(&$variables) {
  if (isset($variables['term'])) {
    // Set base path variable.
    $variables['base_path'] = base_path();
  }
}
```
I'm not sure why we'd set `base_path` in a taxonomy term preprocess but I didn't want to remove it if it's used. If it does belong here then maybe we could change the comment from `// Set base path variable.` to a quick explanation of what it's for. Right now the comment is redundant.

```php
          // Image title.
          if (!empty($image->title)) {
```
Some other comments are not very informative or entirely redundant but I didn't make any changes in this PR.